### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 yacs
 opencv-python
+cython
 cython-bbox
 scipy
 numba


### PR DESCRIPTION
Without cython previously installed cython-bbox throws errors and can't be build.