### PR TITLE
Update README with corrected link for 2DMOT15 dataset (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd src/lib/models/networks/DCNv2 sh make.sh
 
 We use the same training data as [JDE](https://github.com/Zhongdao/Towards-Realtime-MOT). Please refer to their [DATA ZOO](https://github.com/Zhongdao/Towards-Realtime-MOT/blob/master/DATASET_ZOO.md) to download and prepare all the training data including Caltech Pedestrian, CityPersons, CUHK-SYSU, PRW, ETHZ, MOT17 and MOT16. 
 
-[2DMOT15](https://motchallenge.net/data/2D_MOT_2015/) and [MOT20](https://motchallenge.net/data/MOT20/) can be downloaded from the official webpage of MOT challenge. After downloading, you should prepare the data in the following structure:
+[2DMOT15](https://motchallenge.net/data/MOT15/) and [MOT20](https://motchallenge.net/data/MOT20/) can be downloaded from the official webpage of MOT challenge. After downloading, you should prepare the data in the following structure:
 ```
 MOT15
    |——————images


### PR DESCRIPTION
## Link Update in README

### Purpose:
The previous link to the 2DMOT15 dataset in the README was broken, leading to a "NOT FOUND" page.

### Changes Made:
Replaced the outdated link with the correct, working link to ensure users have access to the dataset.

### Impact:
Users can now directly access the 2DMOT15 dataset from the README without any issues.

Related to #18 .
